### PR TITLE
Add momentum for steering signal

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -7,3 +7,4 @@ robot:
   differential:
     left: 1.0
     right: 0.9
+  buffer_size: 10


### PR DESCRIPTION
Add momentum to the steering signal, calculated as the exponential average of the last `buffer_size` signals. It is initialized as an empty buffer, therefore it is not ready for deployment yet, as we need to figure out what to use for the warm-up. 

`buffer_size` can be set in `config.yml` file.

@jotpacanowski  @JanekDev  @konstanty-kordas  Do you have any ideas what to do for the warm-up phase (i.e., how to start)? Do we just fill the buffer with the `forward` steering signal? 